### PR TITLE
Ability to specify Authorization header

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -17,9 +17,12 @@ type session struct {
 	errChan chan error
 }
 
-func connect(url, origin string, rlConf *readline.Config) error {
+func connect(url, origin string, authHeader string, rlConf *readline.Config) error {
 	headers := make(http.Header)
 	headers.Add("Origin", origin)
+	if authHeader != "" {
+		headers.Add("Authorization", authHeader)
+	}
 
 	ws, _, err := websocket.DefaultDialer.Dial(url, headers)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ const Version = "0.2.1"
 var options struct {
 	origin       string
 	printVersion bool
+	authHeader   string
 }
 
 func main() {
@@ -27,6 +28,7 @@ func main() {
 	}
 	rootCmd.Flags().StringVarP(&options.origin, "origin", "o", "", "websocket origin")
 	rootCmd.Flags().BoolVarP(&options.printVersion, "version", "v", false, "print version")
+	rootCmd.Flags().StringVarP(&options.authHeader, "auth_header", "a", "", "auth header, like 'Bearer $TOKEN'")
 
 	rootCmd.Execute()
 }
@@ -67,7 +69,7 @@ func root(cmd *cobra.Command, args []string) {
 		historyFile = filepath.Join(user.HomeDir, ".ws_history")
 	}
 
-	err = connect(dest.String(), origin, &readline.Config{
+	err = connect(dest.String(), origin, options.authHeader, &readline.Config{
 		Prompt:      "> ",
 		HistoryFile: historyFile,
 	})


### PR DESCRIPTION
Hi!

Ws seems very cool and useful, thank you!

This pr adds the ability to specify authorization header, like 

```
curl -H 'Authorization: Bearer $TOKEN' ...
```

please consider merging!

Best wishes,
Vladimir